### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven-checks.yml
+++ b/.github/workflows/maven-checks.yml
@@ -11,6 +11,9 @@ on:
       - master
       - develop
 
+permissions:
+  contents: read
+
 env:
   jsonSecretKey: 'fakeSecretKey'
   frontendDomainUrl: 'http://localhost:5173'


### PR DESCRIPTION
Potential fix for [https://github.com/ved-asole/eKart-ecommerce-backend/security/code-scanning/1](https://github.com/ved-asole/eKart-ecommerce-backend/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Based on the tasks performed in the workflow (e.g., building, testing, and verifying Maven projects), the `contents: read` permission is sufficient. This ensures that the workflow can read repository contents without granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
